### PR TITLE
:bug: Removing route redirect to fix bug with AWS

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -16,9 +16,7 @@ const mainRouter = () => {
 				<Switch>
 					<Route path="/create" component={CreateDestination} />
 					<Route path="/destinations" component={DestinationView} />
-					<Route exact path="/">
-						<Redirect to="/create" />
-					</Route>
+					<Route exact path="/" components={CreateDestination}></Route>
 				</Switch>
 			</Router>
 		</>


### PR DESCRIPTION
Issue: While viewing the live demo on AWS and being on a route such as `/create` or `/destinations`, if you hit `ctrl` / `cmd` + `r` to reload the page or hit the reload button then the app throws a 404 error. This is because I had `<Route exact path="/"><Redirect to="/create"/></Route>` This works fine while using a local server, but with my current AWS bucket settings and app configuration, it tries to reload the `/create` route which only exists once the React DOM has mounted.

For now, I have fixed this by using this as the default route `<Route exact path="/" component={CreateDestination}/>